### PR TITLE
specify exact path for find to avoid GNU conflict

### DIFF
--- a/src/services/find-available-port.service.js
+++ b/src/services/find-available-port.service.js
@@ -22,7 +22,7 @@ export default () =>
       // Similar command to lsof
       // Finds if the specified port is in use
       const command = /^win/.test(os.platform())
-        ? `netstat -aon | find "${port}"`
+        ? `netstat -aon | C:\\WINDOWS\\system32\\find "${port}"`
         : `lsof -i :${port}`;
       childProcess.exec(command, (err, res) => {
         // Ugh, childProcess assumes that no output means that there was an


### PR DESCRIPTION
Thanks for your contribution!

Please fill out the following template with details about your pull request:

**Summary**
When running on a Windows system with Git Bash / GNU utils installed, `find` is ambiguous - it could refer to Windows find (a stream search similar to grep) or GNU find (a filesystem search). Conflict can be avoided by specifying the full path to the Windows executable.